### PR TITLE
Perform local immediate refresh instead of background refresh

### DIFF
--- a/src/org/vaadin/jonatan/autorefresher/OSXRefreshProvider.java
+++ b/src/org/vaadin/jonatan/autorefresher/OSXRefreshProvider.java
@@ -4,6 +4,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.refresh.IRefreshMonitor;
 import org.eclipse.core.resources.refresh.IRefreshResult;
 import org.eclipse.core.resources.refresh.RefreshProvider;
+import org.eclipse.core.runtime.CoreException;
 import org.vaadin.jonatan.nativefsevents.NativeFSEvents;
 import org.vaadin.jonatan.nativefsevents.NativeFSEvents.NativeFSEventListener;
 
@@ -40,7 +41,11 @@ public class OSXRefreshProvider extends RefreshProvider {
 		}
 
 		public void pathModified(String path) {
-			result.refresh(resource);
+			try {
+				resource.refreshLocal(IResource.DEPTH_INFINITE, null);
+			} catch (CoreException e) {
+				e.printStackTrace();
+			}
 		}
 	}
 }


### PR DESCRIPTION
First off, thanks for writing and sharing this helpful little plugin.  I found the refresh mechanism to be too slow in my case, where I'm modifying files with an external editor and I want Eclipse to re-build the project as soon as I save a file.  Using the `refreshLocal` method seems to reduce the refresh time from 5-10 seconds to 1-2 seconds.  You don't have to merge this PR, but I just wanted to post this code in case someone else is in the same situation.  Cheers :)
